### PR TITLE
feat: add mass-upload plugin

### DIFF
--- a/plugins/mass-upload/client/index.ts
+++ b/plugins/mass-upload/client/index.ts
@@ -1,0 +1,662 @@
+import type { ClientPluginAPI } from '../../../types/client';
+
+const { React } = (window as any).__mnemoPluginDeps;
+const { createElement: h, useState, useRef, useCallback } = React;
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+interface ValidatedFile {
+  index: number;
+  originalName: string;
+  resolvedPath: string;
+  size: number;
+  status: 'valid' | 'duplicate' | 'invalid' | 'warning';
+  errors: string[];
+  existingNote?: string;
+}
+
+interface ValidateResponse {
+  sessionId: string;
+  targetFolder: string;
+  preserveStructure: boolean;
+  files: ValidatedFile[];
+}
+
+interface ConfirmResponse {
+  created: number;
+  overwritten: number;
+  errors: string[];
+}
+
+type FileAction = 'create' | 'skip' | 'overwrite';
+
+// ─── Styles (inline) ─────────────────────────────────────────────────────────
+
+const S = {
+  overlay: {
+    position: 'fixed' as const,
+    inset: 0,
+    background: 'rgba(0,0,0,0.6)',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    zIndex: 9999,
+  },
+  modal: {
+    background: 'var(--color-surface-900, #1a1a2e)',
+    color: '#e2e8f0',
+    borderRadius: 12,
+    width: '100%',
+    maxWidth: 600,
+    maxHeight: '80vh',
+    overflowY: 'auto' as const,
+    padding: 28,
+    boxShadow: '0 20px 60px rgba(0,0,0,0.5)',
+  },
+  title: {
+    fontSize: 18,
+    fontWeight: 600,
+    marginBottom: 20,
+    color: '#f1f5f9',
+  },
+  label: {
+    display: 'block',
+    fontSize: 13,
+    color: '#94a3b8',
+    marginBottom: 4,
+  },
+  input: {
+    width: '100%',
+    background: 'rgba(255,255,255,0.06)',
+    border: '1px solid rgba(255,255,255,0.12)',
+    borderRadius: 6,
+    padding: '7px 10px',
+    color: '#e2e8f0',
+    fontSize: 14,
+    boxSizing: 'border-box' as const,
+    outline: 'none',
+  },
+  dropzone: (active: boolean) => ({
+    border: `2px dashed ${active ? '#7c3aed' : 'rgba(255,255,255,0.2)'}`,
+    borderRadius: 8,
+    padding: '32px 20px',
+    textAlign: 'center' as const,
+    color: '#94a3b8',
+    fontSize: 14,
+    cursor: 'pointer',
+    background: active ? 'rgba(124,58,237,0.08)' : 'rgba(255,255,255,0.03)',
+    transition: 'all 0.15s',
+    marginBottom: 16,
+  }),
+  btnPrimary: {
+    background: '#7c3aed',
+    color: '#fff',
+    border: 'none',
+    borderRadius: 6,
+    padding: '8px 18px',
+    fontSize: 14,
+    fontWeight: 500,
+    cursor: 'pointer',
+  },
+  btnSecondary: {
+    background: 'transparent',
+    color: '#94a3b8',
+    border: '1px solid rgba(255,255,255,0.18)',
+    borderRadius: 6,
+    padding: '8px 18px',
+    fontSize: 14,
+    fontWeight: 500,
+    cursor: 'pointer',
+  },
+  btnRow: {
+    display: 'flex',
+    gap: 10,
+    justifyContent: 'flex-end',
+    marginTop: 20,
+  },
+  section: {
+    marginBottom: 16,
+  },
+  checkRow: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: 8,
+    fontSize: 14,
+    color: '#cbd5e1',
+    cursor: 'pointer',
+  },
+  fileList: {
+    fontSize: 12,
+    color: '#64748b',
+    marginTop: 8,
+    maxHeight: 80,
+    overflowY: 'auto' as const,
+  },
+  table: {
+    width: '100%',
+    borderCollapse: 'collapse' as const,
+    fontSize: 13,
+  },
+  th: {
+    textAlign: 'left' as const,
+    color: '#64748b',
+    padding: '6px 8px',
+    borderBottom: '1px solid rgba(255,255,255,0.08)',
+    fontWeight: 500,
+  },
+  td: (opacity?: number) => ({
+    padding: '6px 8px',
+    borderBottom: '1px solid rgba(255,255,255,0.05)',
+    verticalAlign: 'top' as const,
+    opacity: opacity ?? 1,
+  }),
+  select: {
+    background: 'rgba(255,255,255,0.06)',
+    border: '1px solid rgba(255,255,255,0.12)',
+    borderRadius: 4,
+    color: '#e2e8f0',
+    padding: '2px 6px',
+    fontSize: 12,
+  },
+  summary: {
+    fontSize: 13,
+    color: '#94a3b8',
+    marginBottom: 14,
+  },
+  resultRow: {
+    display: 'flex',
+    gap: 24,
+    marginBottom: 16,
+  },
+  resultStat: {
+    textAlign: 'center' as const,
+  },
+  resultNum: {
+    fontSize: 28,
+    fontWeight: 700,
+    color: '#7c3aed',
+  },
+  resultLabel: {
+    fontSize: 12,
+    color: '#64748b',
+  },
+  errorList: {
+    background: 'rgba(239,68,68,0.08)',
+    border: '1px solid rgba(239,68,68,0.25)',
+    borderRadius: 6,
+    padding: '10px 14px',
+    fontSize: 13,
+    color: '#fca5a5',
+    marginTop: 12,
+  },
+};
+
+// ─── Status Badge ─────────────────────────────────────────────────────────────
+
+function StatusBadge({ status }: { status: ValidatedFile['status'] }): any {
+  const colors: Record<string, string> = {
+    valid: '#22c55e',
+    warning: '#eab308',
+    duplicate: '#eab308',
+    invalid: '#ef4444',
+  };
+  return h('span', {
+    style: {
+      display: 'inline-flex',
+      alignItems: 'center',
+      gap: 5,
+      fontSize: 12,
+      color: colors[status] ?? '#94a3b8',
+      whiteSpace: 'nowrap' as const,
+    },
+  },
+    h('span', {
+      style: {
+        width: 8,
+        height: 8,
+        borderRadius: '50%',
+        background: colors[status] ?? '#94a3b8',
+        display: 'inline-block',
+        flexShrink: 0,
+      },
+    }),
+    status,
+  );
+}
+
+// ─── Step 1: Select Files ─────────────────────────────────────────────────────
+
+function StepSelect({
+  api,
+  onValidated,
+  onCancel,
+}: {
+  api: ClientPluginAPI;
+  onValidated: (data: ValidateResponse) => void;
+  onCancel: () => void;
+}): any {
+  const [files, setFiles] = useState<File[]>([]);
+  const [targetFolder, setTargetFolder] = useState('');
+  const [preserveStructure, setPreserveStructure] = useState(true);
+  const [dragging, setDragging] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const addFiles = useCallback((incoming: FileList | File[]) => {
+    const mdFiles = Array.from(incoming).filter((f) =>
+      f.name.toLowerCase().endsWith('.md'),
+    );
+    setFiles((prev) => {
+      const existing = new Set(prev.map((f) => f.name + f.size));
+      const fresh = mdFiles.filter((f) => !existing.has(f.name + f.size));
+      return [...prev, ...fresh];
+    });
+  }, []);
+
+  function handleDrop(e: DragEvent): void {
+    e.preventDefault();
+    setDragging(false);
+    if (e.dataTransfer?.files) addFiles(e.dataTransfer.files);
+  }
+
+  function handleDragOver(e: DragEvent): void {
+    e.preventDefault();
+    setDragging(true);
+  }
+
+  function handleDragLeave(): void {
+    setDragging(false);
+  }
+
+  async function handleValidate(): Promise<void> {
+    if (files.length === 0) {
+      setError('Please select at least one .md file.');
+      return;
+    }
+    setError('');
+    setLoading(true);
+    try {
+      const formData = new FormData();
+      files.forEach((f) => formData.append('files', f));
+      const params = new URLSearchParams();
+      if (targetFolder.trim()) params.set('targetFolder', targetFolder.trim());
+      params.set('preserveStructure', String(preserveStructure));
+
+      const res = await (api as any).api.fetch(`/validate?${params}`, {
+        method: 'POST',
+        body: formData,
+        // Do NOT set Content-Type — browser handles multipart boundary
+      });
+
+      if (!res.ok) {
+        const msg = await res.text().catch(() => 'Unknown error');
+        setError(`Validation failed: ${msg}`);
+        return;
+      }
+
+      const data = (await res.json()) as ValidateResponse;
+      onValidated(data);
+    } catch (err: any) {
+      setError(err?.message ?? 'Validation failed');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return h('div', null,
+    h('div', { style: S.title }, 'Upload Notes — Step 1: Select Files'),
+
+    // Drop zone
+    h('div', {
+      style: S.dropzone(dragging),
+      onDrop: handleDrop,
+      onDragOver: handleDragOver,
+      onDragLeave: handleDragLeave,
+      onClick: () => fileInputRef.current?.click(),
+    },
+      h('div', null, 'Drag & drop .md files here'),
+      h('div', { style: { marginTop: 6, fontSize: 12 } }, 'or click to browse'),
+    ),
+
+    // Hidden file input
+    h('input', {
+      ref: fileInputRef,
+      type: 'file',
+      accept: '.md',
+      multiple: true,
+      style: { display: 'none' },
+      onChange: (e: any) => {
+        if (e.target.files) addFiles(e.target.files);
+        e.target.value = '';
+      },
+    }),
+
+    // Selected files list
+    files.length > 0 && h('div', { style: S.fileList },
+      `${files.length} file(s) selected:`,
+      files.map((f, i) =>
+        h('div', { key: i, style: { marginTop: 2 } }, f.name),
+      ),
+    ),
+
+    // Target folder
+    h('div', { style: S.section },
+      h('label', { style: S.label }, 'Target folder (leave empty for root)'),
+      h('input', {
+        type: 'text',
+        style: S.input,
+        value: targetFolder,
+        placeholder: 'e.g. Notes/Imported',
+        onChange: (e: any) => setTargetFolder(e.target.value),
+      }),
+    ),
+
+    // Preserve structure checkbox
+    h('div', { style: { ...S.section, marginBottom: 0 } },
+      h('label', { style: S.checkRow },
+        h('input', {
+          type: 'checkbox',
+          checked: preserveStructure,
+          onChange: (e: any) => setPreserveStructure(e.target.checked),
+        }),
+        'Preserve folder structure',
+      ),
+    ),
+
+    // Error
+    error && h('div', {
+      style: { color: '#f87171', fontSize: 13, marginTop: 12 },
+    }, error),
+
+    // Buttons
+    h('div', { style: S.btnRow },
+      h('button', { style: S.btnSecondary, onClick: onCancel }, 'Cancel'),
+      h('button', {
+        style: {
+          ...S.btnPrimary,
+          opacity: loading ? 0.7 : 1,
+          cursor: loading ? 'not-allowed' : 'pointer',
+        },
+        onClick: handleValidate,
+        disabled: loading,
+      }, loading ? 'Validating...' : 'Upload & Validate'),
+    ),
+  );
+}
+
+// ─── Step 2: Review ───────────────────────────────────────────────────────────
+
+function StepReview({
+  api,
+  data,
+  onDone,
+  onCancel,
+}: {
+  api: ClientPluginAPI;
+  data: ValidateResponse;
+  onDone: (result: ConfirmResponse) => void;
+  onCancel: () => void;
+}): any {
+  const initialActions: Record<number, FileAction> = {};
+  for (const f of data.files) {
+    if (f.status === 'invalid') {
+      initialActions[f.index] = 'skip';
+    } else if (f.status === 'duplicate') {
+      initialActions[f.index] = 'skip';
+    } else {
+      initialActions[f.index] = 'create';
+    }
+  }
+
+  const [actions, setActions] = useState<Record<number, FileAction>>(initialActions);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  const validCount = data.files.filter((f) => f.status === 'valid').length;
+  const warningCount = data.files.filter((f) => f.status === 'warning').length;
+  const dupCount = data.files.filter((f) => f.status === 'duplicate').length;
+  const invalidCount = data.files.filter((f) => f.status === 'invalid').length;
+
+  const importCount = data.files.filter(
+    (f) => actions[f.index] !== 'skip',
+  ).length;
+
+  async function handleConfirm(): Promise<void> {
+    setError('');
+    setLoading(true);
+    try {
+      const payload = {
+        sessionId: data.sessionId,
+        files: data.files.map((f) => ({
+          index: f.index,
+          action: actions[f.index] ?? 'skip',
+        })),
+      };
+
+      const res = await (api as any).api.fetch('/confirm', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+
+      if (!res.ok) {
+        const msg = await res.text().catch(() => 'Unknown error');
+        setError(`Import failed: ${msg}`);
+        return;
+      }
+
+      const result = (await res.json()) as ConfirmResponse;
+      onDone(result);
+    } catch (err: any) {
+      setError(err?.message ?? 'Import failed');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function handleCancel(): Promise<void> {
+    try {
+      await (api as any).api.fetch(`/session/${data.sessionId}`, {
+        method: 'DELETE',
+      });
+    } catch {
+      // best effort
+    }
+    onCancel();
+  }
+
+  return h('div', null,
+    h('div', { style: S.title }, 'Upload Notes — Step 2: Review'),
+
+    // Summary
+    h('div', { style: S.summary },
+      `${validCount} valid, ${warningCount} warning(s), ${dupCount} duplicate(s), ${invalidCount} invalid`,
+    ),
+
+    // File table
+    h('div', { style: { overflowX: 'auto' as const, marginBottom: 12 } },
+      h('table', { style: S.table },
+        h('thead', null,
+          h('tr', null,
+            h('th', { style: S.th }, 'Path'),
+            h('th', { style: S.th }, 'Status'),
+            h('th', { style: S.th }, 'Action'),
+            h('th', { style: S.th }, 'Errors'),
+          ),
+        ),
+        h('tbody', null,
+          data.files.map((f) => {
+            const isInvalid = f.status === 'invalid';
+            const isDup = f.status === 'duplicate';
+
+            return h('tr', { key: f.index },
+              // Path
+              h('td', { style: { ...S.td(isInvalid ? 0.5 : 1), wordBreak: 'break-all' as const, maxWidth: 220 } },
+                f.resolvedPath,
+              ),
+              // Status
+              h('td', { style: S.td(isInvalid ? 0.5 : 1) },
+                h(StatusBadge, { status: f.status }),
+              ),
+              // Action
+              h('td', { style: S.td() },
+                isDup
+                  ? h('select', {
+                      style: S.select,
+                      value: actions[f.index] ?? 'skip',
+                      onChange: (e: any) =>
+                        setActions((prev) => ({
+                          ...prev,
+                          [f.index]: e.target.value as FileAction,
+                        })),
+                    },
+                      h('option', { value: 'skip' }, 'Skip'),
+                      h('option', { value: 'overwrite' }, 'Overwrite'),
+                    )
+                  : h('span', {
+                      style: { fontSize: 12, color: isInvalid ? '#64748b' : '#94a3b8' },
+                    }, isInvalid ? '—' : 'create'),
+              ),
+              // Errors
+              h('td', { style: { ...S.td(), color: '#f87171', fontSize: 12, maxWidth: 180 } },
+                f.errors && f.errors.length > 0
+                  ? f.errors.join('; ')
+                  : null,
+              ),
+            );
+          }),
+        ),
+      ),
+    ),
+
+    error && h('div', {
+      style: { color: '#f87171', fontSize: 13, marginBottom: 10 },
+    }, error),
+
+    h('div', { style: S.btnRow },
+      h('button', { style: S.btnSecondary, onClick: handleCancel }, 'Cancel'),
+      h('button', {
+        style: {
+          ...S.btnPrimary,
+          opacity: loading || importCount === 0 ? 0.6 : 1,
+          cursor: loading || importCount === 0 ? 'not-allowed' : 'pointer',
+        },
+        onClick: handleConfirm,
+        disabled: loading || importCount === 0,
+      }, loading ? 'Importing...' : `Import ${importCount} file(s)`),
+    ),
+  );
+}
+
+// ─── Step 3: Results ──────────────────────────────────────────────────────────
+
+function StepResults({
+  result,
+  onClose,
+}: {
+  result: ConfirmResponse;
+  onClose: () => void;
+}): any {
+  return h('div', null,
+    h('div', { style: S.title }, 'Upload Notes — Done'),
+
+    h('div', { style: S.resultRow },
+      h('div', { style: S.resultStat },
+        h('div', { style: S.resultNum }, result.created),
+        h('div', { style: S.resultLabel }, 'Created'),
+      ),
+      h('div', { style: S.resultStat },
+        h('div', { style: { ...S.resultNum, color: '#a78bfa' } }, result.overwritten),
+        h('div', { style: S.resultLabel }, 'Overwritten'),
+      ),
+    ),
+
+    result.errors && result.errors.length > 0 && h('div', { style: S.errorList },
+      h('div', { style: { fontWeight: 600, marginBottom: 6 } }, 'Errors:'),
+      result.errors.map((e, i) =>
+        h('div', { key: i, style: { marginTop: 3 } }, e),
+      ),
+    ),
+
+    h('div', { style: S.btnRow },
+      h('button', { style: S.btnPrimary, onClick: onClose }, 'Done'),
+    ),
+  );
+}
+
+// ─── Modal Wrapper ────────────────────────────────────────────────────────────
+
+function UploadModal({ api, onClose }: { api: ClientPluginAPI; onClose: () => void }): any {
+  const [step, setStep] = useState<'select' | 'review' | 'results'>('select');
+  const [validated, setValidated] = useState<ValidateResponse | null>(null);
+  const [result, setResult] = useState<ConfirmResponse | null>(null);
+
+  function handleValidated(data: ValidateResponse): void {
+    setValidated(data);
+    setStep('review');
+  }
+
+  function handleDone(res: ConfirmResponse): void {
+    setResult(res);
+    setStep('results');
+  }
+
+  function handleOverlayClick(e: any): void {
+    if (e.target === e.currentTarget) onClose();
+  }
+
+  return h('div', { style: S.overlay, onClick: handleOverlayClick },
+    h('div', { style: S.modal, onClick: (e: any) => e.stopPropagation() },
+      step === 'select' && h(StepSelect, {
+        api,
+        onValidated: handleValidated,
+        onCancel: onClose,
+      }),
+      step === 'review' && validated && h(StepReview, {
+        api,
+        data: validated,
+        onDone: handleDone,
+        onCancel: onClose,
+      }),
+      step === 'results' && result && h(StepResults, {
+        result,
+        onClose,
+      }),
+    ),
+  );
+}
+
+// ─── Toolbar Button ───────────────────────────────────────────────────────────
+
+function UploadButton({ api }: { api: ClientPluginAPI }): any {
+  const [open, setOpen] = useState(false);
+
+  return h('span', null,
+    h('button', {
+      onClick: () => setOpen(true),
+      title: 'Mass upload notes',
+      style: {
+        background: 'transparent',
+        border: 'none',
+        cursor: 'pointer',
+        color: 'inherit',
+        fontSize: 14,
+        padding: '4px 8px',
+        borderRadius: 4,
+      },
+    }, '\u2B06 Upload'),
+    open && h(UploadModal, { api, onClose: () => setOpen(false) }),
+  );
+}
+
+// ─── Plugin entry points ──────────────────────────────────────────────────────
+
+export function activate(api: ClientPluginAPI): void {
+  (api as any).ui.registerEditorToolbarButton(
+    () => h(UploadButton, { api }),
+    { id: 'mass-upload-btn', order: 100 },
+  );
+}
+
+export function deactivate(): void {}

--- a/plugins/mass-upload/manifest.json
+++ b/plugins/mass-upload/manifest.json
@@ -1,0 +1,19 @@
+{
+  "id": "mass-upload",
+  "name": "Mass Upload",
+  "version": "1.0.0",
+  "description": "Bulk import .md files with validation and duplicate detection",
+  "author": "Mnemo",
+  "minMnemoVersion": "3.0.0",
+  "server": "server/index.js",
+  "client": "client/index.js",
+  "settings": [
+    {
+      "key": "maxFileSize",
+      "type": "number",
+      "default": 1048576,
+      "label": "Max file size (bytes)",
+      "perUser": false
+    }
+  ]
+}

--- a/plugins/mass-upload/server/index.ts
+++ b/plugins/mass-upload/server/index.ts
@@ -119,9 +119,9 @@ export function createHandlers(api: PluginAPI, sessionStore: SessionStore) {
           return;
         }
 
-        const { sessionId, actions } = req.body as {
+        const { sessionId, files: actions } = req.body as {
           sessionId?: string;
-          actions?: Array<{ index: number; action: "create" | "overwrite" | "skip" }>;
+          files?: Array<{ index: number; action: "create" | "overwrite" | "skip" }>;
         };
 
         if (!sessionId) {
@@ -135,8 +135,8 @@ export function createHandlers(api: PluginAPI, sessionStore: SessionStore) {
           return;
         }
 
-        const created: string[] = [];
-        const overwritten: string[] = [];
+        let created = 0;
+        let overwritten = 0;
         const errors: Array<{ index: number; error: string }> = [];
 
         const fileActions = actions ?? [];
@@ -166,10 +166,10 @@ export function createHandlers(api: PluginAPI, sessionStore: SessionStore) {
           try {
             if (action.action === "create") {
               await api.notes.create(userId, fileEntry.resolvedPath, content);
-              created.push(fileEntry.resolvedPath);
+              created++;
             } else if (action.action === "overwrite") {
               await api.notes.update(userId, fileEntry.resolvedPath, content);
-              overwritten.push(fileEntry.resolvedPath);
+              overwritten++;
             }
           } catch (noteErr: any) {
             errors.push({

--- a/plugins/mass-upload/server/index.ts
+++ b/plugins/mass-upload/server/index.ts
@@ -1,0 +1,253 @@
+import type { Request, Response } from "express";
+import * as fs from "fs/promises";
+import * as path from "path";
+import * as os from "os";
+import multer from "multer";
+
+import type { PluginAPI } from "../../../types/server";
+import { SessionStore } from "./sessionStore.js";
+import { validateFile, flattenNotePaths } from "./validation.js";
+
+// Track in-flight confirm promises for graceful shutdown
+const inFlightConfirms = new Set<Promise<unknown>>();
+
+let globalSessionStore: SessionStore | null = null;
+
+export function createHandlers(api: PluginAPI, sessionStore: SessionStore) {
+  const validate = async (req: Request, res: Response): Promise<void> => {
+    try {
+      const userId: string | undefined = (req as any).user?.id;
+      if (!userId) {
+        res.status(401).json({ error: "Unauthorized" });
+        return;
+      }
+
+      const maxFileSize =
+        ((await api.settings.get("maxFileSize")) as number) || 1048576;
+
+      const upload = multer({
+        storage: multer.memoryStorage(),
+        limits: { files: 500, fileSize: maxFileSize },
+      });
+
+      try {
+        await new Promise<void>((resolve, reject) => {
+          upload.array("files", 500)(req as any, res as any, (err: any) =>
+            err ? reject(err) : resolve()
+          );
+        });
+      } catch (multerErr: any) {
+        res.status(400).json({ error: multerErr.message || "Upload failed" });
+        return;
+      }
+
+      const targetFolder =
+        typeof req.query["targetFolder"] === "string"
+          ? req.query["targetFolder"]
+          : "";
+      const preserveStructure = req.query["preserveStructure"] === "true";
+
+      const session = await sessionStore.create(userId);
+      session.targetFolder = targetFolder;
+      session.preserveStructure = preserveStructure;
+
+      // Fetch existing note paths for duplicate detection
+      const noteTree = await api.notes.list(userId);
+      const existingPaths = flattenNotePaths(noteTree);
+
+      const uploadedFiles = (req as any).files as Express.Multer.File[];
+
+      for (let i = 0; i < uploadedFiles.length; i++) {
+        const file = uploadedFiles[i];
+        const originalName = file.originalname;
+
+        // Build resolved path
+        let resolvedPath: string;
+        if (preserveStructure && (file as any).fieldname === "files") {
+          // Use the relative path from the file's webkitRelativePath-style name if provided
+          // Otherwise fall back to originalname
+          resolvedPath = path.posix.join(targetFolder, originalName);
+        } else {
+          resolvedPath = path.posix.join(
+            targetFolder,
+            path.basename(originalName)
+          );
+        }
+
+        const content = file.buffer;
+        const result = validateFile(
+          originalName,
+          resolvedPath,
+          content,
+          maxFileSize,
+          existingPaths
+        );
+
+        // Write file content to session dir for later use in confirm
+        const sessionFilePath = path.join(session.dir, String(i) + ".md");
+        await fs.writeFile(sessionFilePath, content);
+
+        session.files.push({
+          index: i,
+          originalName: result.originalName,
+          resolvedPath: result.resolvedPath,
+          size: result.size,
+          status: result.status,
+          errors: result.errors,
+          existingNote: result.existingNote,
+        });
+      }
+
+      res.json({
+        sessionId: session.id,
+        targetFolder: session.targetFolder,
+        preserveStructure: session.preserveStructure,
+        files: session.files,
+      });
+    } catch (err: any) {
+      api.log.error("Mass Upload /validate error", err);
+      res.status(500).json({ error: "Validation failed" });
+    }
+  };
+
+  const confirm = async (req: Request, res: Response): Promise<void> => {
+    const work = async () => {
+      try {
+        const userId: string | undefined = (req as any).user?.id;
+        if (!userId) {
+          res.status(401).json({ error: "Unauthorized" });
+          return;
+        }
+
+        const { sessionId, actions } = req.body as {
+          sessionId?: string;
+          actions?: Array<{ index: number; action: "create" | "overwrite" | "skip" }>;
+        };
+
+        if (!sessionId) {
+          res.status(400).json({ error: "sessionId is required" });
+          return;
+        }
+
+        const session = sessionStore.get(sessionId, userId);
+        if (!session) {
+          res.status(410).json({ error: "Session not found or expired" });
+          return;
+        }
+
+        const created: string[] = [];
+        const overwritten: string[] = [];
+        const errors: Array<{ index: number; error: string }> = [];
+
+        const fileActions = actions ?? [];
+
+        for (const action of fileActions) {
+          const fileEntry = session.files[action.index];
+          if (!fileEntry) {
+            errors.push({ index: action.index, error: "File index out of range" });
+            continue;
+          }
+
+          if (action.action === "skip") continue;
+
+          const sessionFilePath = path.join(
+            session.dir,
+            String(action.index) + ".md"
+          );
+
+          let content: string;
+          try {
+            content = await fs.readFile(sessionFilePath, "utf-8");
+          } catch {
+            errors.push({ index: action.index, error: "Could not read session file" });
+            continue;
+          }
+
+          try {
+            if (action.action === "create") {
+              await api.notes.create(userId, fileEntry.resolvedPath, content);
+              created.push(fileEntry.resolvedPath);
+            } else if (action.action === "overwrite") {
+              await api.notes.update(userId, fileEntry.resolvedPath, content);
+              overwritten.push(fileEntry.resolvedPath);
+            }
+          } catch (noteErr: any) {
+            errors.push({
+              index: action.index,
+              error: noteErr?.message || "Failed to write note",
+            });
+          }
+        }
+
+        await sessionStore.delete(sessionId, userId);
+
+        res.json({ created, overwritten, errors });
+      } catch (err: any) {
+        api.log.error("Mass Upload /confirm error", err);
+        res.status(500).json({ error: "Confirm failed" });
+      }
+    };
+
+    const p = work();
+    inFlightConfirms.add(p);
+    p.finally(() => inFlightConfirms.delete(p));
+    await p;
+  };
+
+  const deleteSession = async (req: Request, res: Response): Promise<void> => {
+    try {
+      const userId: string | undefined = (req as any).user?.id;
+      if (!userId) {
+        res.status(401).json({ error: "Unauthorized" });
+        return;
+      }
+
+      const { sessionId } = req.params;
+      const deleted = await sessionStore.delete(sessionId, userId);
+      if (!deleted) {
+        res.status(404).json({ error: "Session not found" });
+        return;
+      }
+      res.json({ deleted: true });
+    } catch (err: any) {
+      api.log.error("Mass Upload DELETE /session error", err);
+      res.status(500).json({ error: "Delete failed" });
+    }
+  };
+
+  return { validate, confirm, deleteSession };
+}
+
+export function activate(api: PluginAPI): void {
+  api.log.info("Mass Upload plugin activated");
+
+  const baseDir = path.join(os.tmpdir(), "mnemo-mass-upload");
+  const sessionStore = new SessionStore(baseDir, {
+    maxPerUser: 5,
+    expiryMs: 30 * 60 * 1000,
+  });
+  globalSessionStore = sessionStore;
+
+  const handlers = createHandlers(api, sessionStore);
+
+  api.routes.register("post", "/validate", handlers.validate as any);
+  api.routes.register("post", "/confirm", handlers.confirm as any);
+  api.routes.register(
+    "delete",
+    "/session/:sessionId",
+    handlers.deleteSession as any
+  );
+}
+
+export async function deactivate(): Promise<void> {
+  // Await all in-flight confirm operations
+  if (inFlightConfirms.size > 0) {
+    await Promise.allSettled([...inFlightConfirms]);
+  }
+
+  if (globalSessionStore) {
+    await globalSessionStore.cleanAll();
+    globalSessionStore.dispose();
+    globalSessionStore = null;
+  }
+}

--- a/plugins/mass-upload/server/sessionStore.ts
+++ b/plugins/mass-upload/server/sessionStore.ts
@@ -1,0 +1,105 @@
+import * as fs from "fs/promises";
+import * as path from "path";
+import * as crypto from "crypto";
+
+export interface FileEntry {
+  index: number;
+  originalName: string;
+  resolvedPath: string;
+  size: number;
+  status: "valid" | "duplicate" | "warning" | "invalid";
+  errors: string[];
+  existingNote?: boolean;
+}
+
+export interface Session {
+  id: string;
+  userId: string;
+  dir: string;
+  files: FileEntry[];
+  targetFolder: string;
+  preserveStructure: boolean;
+  createdAt: number;
+}
+
+interface StoreOptions {
+  maxPerUser: number;
+  expiryMs: number;
+}
+
+export class SessionStore {
+  private sessions = new Map<string, Session>();
+  private timer: ReturnType<typeof setInterval> | null = null;
+
+  constructor(
+    private baseDir: string,
+    private options: StoreOptions
+  ) {
+    this.timer = setInterval(() => this.cleanExpired(), 5 * 60 * 1000);
+  }
+
+  async create(userId: string): Promise<Session> {
+    const userSessions = [...this.sessions.values()].filter(
+      (s) => s.userId === userId
+    );
+    if (userSessions.length >= this.options.maxPerUser) {
+      throw new Error(
+        `Max concurrent session limit (${this.options.maxPerUser}) reached`
+      );
+    }
+
+    const id = crypto.randomUUID();
+    const dir = path.join(this.baseDir, userId, id);
+    await fs.mkdir(dir, { recursive: true });
+
+    const session: Session = {
+      id,
+      userId,
+      dir,
+      files: [],
+      targetFolder: "",
+      preserveStructure: false,
+      createdAt: Date.now(),
+    };
+    this.sessions.set(id, session);
+    return session;
+  }
+
+  get(sessionId: string, userId: string): Session | null {
+    const session = this.sessions.get(sessionId);
+    if (!session || session.userId !== userId) return null;
+    return session;
+  }
+
+  async delete(sessionId: string, userId: string): Promise<boolean> {
+    const session = this.get(sessionId, userId);
+    if (!session) return false;
+    this.sessions.delete(sessionId);
+    await fs.rm(session.dir, { recursive: true, force: true }).catch(() => {});
+    return true;
+  }
+
+  private async cleanExpired(): Promise<void> {
+    const now = Date.now();
+    for (const [id, session] of this.sessions) {
+      if (now - session.createdAt > this.options.expiryMs) {
+        this.sessions.delete(id);
+        await fs.rm(session.dir, { recursive: true, force: true }).catch(() => {});
+      }
+    }
+  }
+
+  async cleanAll(): Promise<void> {
+    for (const [id, session] of this.sessions) {
+      this.sessions.delete(id);
+      await fs.rm(session.dir, { recursive: true, force: true }).catch(() => {});
+    }
+  }
+
+  dispose(): void {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+  }
+}

--- a/plugins/mass-upload/server/validation.ts
+++ b/plugins/mass-upload/server/validation.ts
@@ -1,0 +1,110 @@
+const WINDOWS_RESERVED = /^(CON|PRN|AUX|NUL|COM\d|LPT\d)$/i;
+
+interface NoteEntry {
+  name: string;
+  path: string;
+  type: "file" | "directory";
+  children?: NoteEntry[];
+}
+
+/** Recursively flatten a NoteEntry tree into a Set of file paths. */
+export function flattenNotePaths(tree: NoteEntry[]): Set<string> {
+  const paths = new Set<string>();
+  function walk(nodes: NoteEntry[]) {
+    for (const node of nodes) {
+      if (node.type === "file") paths.add(node.path);
+      if (node.children) walk(node.children);
+    }
+  }
+  walk(tree);
+  return paths;
+}
+
+export function sanitizePath(filePath: string): string {
+  let p = filePath;
+  p = p.replace(/[\x00-\x1f\x7f]/g, "");
+  p = p.replace(/\.\.\//g, "").replace(/\.\.\\/g, "");
+  p = p.replace(/^[/\\]+/, "");
+  p = p
+    .split("/")
+    .map((seg) => {
+      const base = seg.replace(/\.[^.]*$/, "");
+      if (WINDOWS_RESERVED.test(base)) return "_" + seg;
+      return seg;
+    })
+    .join("/");
+  return p;
+}
+
+export interface ValidationResult {
+  originalName: string;
+  resolvedPath: string;
+  size: number;
+  status: "valid" | "duplicate" | "warning" | "invalid";
+  errors: string[];
+  existingNote?: boolean;
+}
+
+export function validateFile(
+  originalName: string,
+  resolvedPath: string,
+  content: Buffer,
+  maxFileSize: number,
+  existingPaths: Set<string>
+): ValidationResult {
+  const errors: string[] = [];
+  let hasHardError = false;
+
+  if (!originalName.toLowerCase().endsWith(".md")) {
+    errors.push("File must have .md extension");
+    hasHardError = true;
+  }
+
+  if (content.length === 0) {
+    errors.push("File is empty");
+    hasHardError = true;
+  } else if (content.length > maxFileSize) {
+    errors.push(`File size (${content.length} bytes) exceeds maximum (${maxFileSize} bytes)`);
+    hasHardError = true;
+  }
+
+  if (content.length > 0 && content.includes(0)) {
+    errors.push("File contains binary data");
+    hasHardError = true;
+  }
+
+  if (content.length > 0 && !hasHardError) {
+    try {
+      const decoded = new TextDecoder("utf-8", { fatal: true }).decode(content);
+      if (!decoded.trimStart().startsWith("# ")) {
+        errors.push("File does not start with a # heading");
+      }
+    } catch {
+      errors.push("File is not valid UTF-8");
+      hasHardError = true;
+    }
+  }
+
+  const safePath = sanitizePath(resolvedPath);
+  const isDuplicate = existingPaths.has(safePath);
+
+  let status: ValidationResult["status"];
+  if (hasHardError) {
+    status = "invalid";
+  } else if (isDuplicate) {
+    status = "duplicate";
+  } else if (errors.length > 0) {
+    status = "warning";
+  } else {
+    status = "valid";
+  }
+
+  return {
+    originalName,
+    resolvedPath: safePath,
+    size: content.length,
+    status,
+    errors,
+    existingNote: isDuplicate || undefined,
+  };
+}

--- a/registry.json
+++ b/registry.json
@@ -70,6 +70,19 @@
       "icon": "git-branch"
     },
     {
+      "id": "mass-upload",
+      "name": "Mass Upload",
+      "description": "Bulk import .md files with validation and duplicate detection",
+      "author": "Mnemo",
+      "version": "1.0.0",
+      "minMnemoVersion": "3.0.0",
+      "tags": [
+        "import",
+        "productivity"
+      ],
+      "icon": "upload"
+    },
+    {
       "id": "mermaid-diagrams",
       "name": "Mermaid Diagrams",
       "description": "Render Mermaid diagrams in code fences with live preview and theme support",


### PR DESCRIPTION
## Summary
- New mass-upload plugin for bulk importing `.md` files
- Two-phase server flow: upload+validate via multer, then confirm+create
- 3-step client modal: select files, review validation results, confirm import
- File validation: extension, size, binary detection, UTF-8, path safety, heading check
- Duplicate detection with per-file skip/overwrite choice
- Session management with auto-expiry and per-user limits

## Test plan
- [ ] Plugin builds successfully (`npm run build`)
- [ ] Registry validates (`npm run validate`)
- [ ] Upload .md files via the modal and verify they appear as notes
- [ ] Verify invalid files (non-.md, empty, binary) are correctly flagged
- [ ] Verify duplicate detection with skip/overwrite options